### PR TITLE
Fix documentation for repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "done!"
 
-      - uses: "dciborow/action-automatic-releases-2@v1.0.0"
+      - uses: "dciborow/action-automatic-releases@v1.0.1"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
@@ -90,7 +90,7 @@ jobs:
         run: |
           echo "done!"
 
-      - uses: "dciborow/action-automatic-releases-2@v1.0.0"
+      - uses: "dciborow/action-automatic-releases@v1.0.1"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
@@ -135,7 +135,7 @@ The GitHub Actions framework allows you to trigger this (and other) actions on _
 Every commit that lands on master for this project triggers an automatic build as well as a tagged release called `latest`. If you don't wish to live on the bleeding edge you may use a stable release instead. See [releases](../../releases/latest) for the available versions.
 
 ```yaml
-- uses: "marvinpinto/action-automatic-releases@<VERSION>"
+- uses: "dciborow/action-automatic-releases@<VERSION>"
 ```
 
 ## How to get help


### PR DESCRIPTION
The reference used in actions is a direct reference to the *exact* name of the source repository. This one does not have a "-2" suffix, therefore the current references are invalid.